### PR TITLE
Created Setting Up Guide and added espup to it

### DIFF
--- a/.github/workflows/rebase-documentation.yml
+++ b/.github/workflows/rebase-documentation.yml
@@ -22,9 +22,9 @@ jobs:
         run: |
           git fetch origin
 
-      - name: Checkout Documentation Branch and Attempt Rebase
+      - name: Switch Documentation Branch and Attempt Rebase
         run: |
-          git checkout documentation
+          git switch documentation
           if git rebase main; then
             echo "Rebase successful"
           else

--- a/documentation/Setting Up Guide.md
+++ b/documentation/Setting Up Guide.md
@@ -1,0 +1,9 @@
+# Setting Up Guide
+
+## `espup`
+
+Install `espup` and use it for simplifying the installation and maintainance of the components required to develop Rust applications for the `Xtensa` and `RISC-V` architectures.
+
+### Using `rust-build` installation scripts
+
+This was the **recommended** way in the **past**, but **now** the **installation scripts** are **feature frozen**, and **all new features** will **only** be **included** in **`espup`**. See the repository README for instructions.


### PR DESCRIPTION
- Created the file `Setting Up Guide.md`
- Inside it, explained that everyone needs `espup` instead of `rust-build` and why
- Fixed the GitHub Actions workflow to `switch` instead of `checkout`, which tells explicitly that the action is using the branch as opposed to a local file